### PR TITLE
OMP: Remove unused itkv3 header files

### DIFF
--- a/DilateLabel/DilateLabel.cxx
+++ b/DilateLabel/DilateLabel.cxx
@@ -32,8 +32,6 @@
 #include "itkPluginUtilities.h"
 #include "DilateLabelCLP.h"
 
-#include "itkMultiplyByConstantImageFilter.h"
-
 namespace {
 
 template<class T> int DoIt( int argc, char * argv[], T )

--- a/ErodeLabel/ErodeLabel.cxx
+++ b/ErodeLabel/ErodeLabel.cxx
@@ -32,8 +32,6 @@
 #include "itkPluginUtilities.h"
 #include "ErodeLabelCLP.h"
 
-#include "itkMultiplyByConstantImageFilter.h"
-
 namespace {
 
 template<class T> int DoIt( int argc, char * argv[], T )


### PR DESCRIPTION
The class itkMultiplyByConstantImageFilter is only available
ITKv3 compatibility is on. The upcoming Slicer release will turn the
ITKv3 compatibility off.
